### PR TITLE
Update webnn-tutorial.md

### DIFF
--- a/docs/directml/webnn-tutorial.md
+++ b/docs/directml/webnn-tutorial.md
@@ -157,7 +157,7 @@ async function classifyImage(pathToImage){
     // ort.env.debug = true; 
 
     // Configure WebNN.
-    const modelPath = "./mobilenetv2-7.onnx";
+    const modelPath = "./mobilenetv2-10.onnx";
     const devicePreference = "gpu"; // Other options include "npu" and "cpu".
     const options = {
 	    executionProviders: [{ name: "webnn", deviceType: devicePreference, powerPreference: "default" }],


### PR DESCRIPTION
Docs indicate the use of  the mobilenet2-**10**.onnx model. But the code snippets still use the mobilenet2-**7**.onnx model.

Tried the tutorial and it is only working with the mobilenet2-**10**.onnx model